### PR TITLE
Add docker suport

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,5 +42,6 @@ jobs:
         with:
           load: true
           push: true
+          file: ./docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,46 @@
+name: Build and publish Docker image
+
+on:
+  pull_request:
+  push: [main, master]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses:
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            # Set the latest tag for pushes to the main branch only
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          load: true
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -24,7 +24,9 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses:
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches: [main, master]
+    branches: ~
   pull_request:
-    branches: [main, master]
+    branches: ~
 
 name: Build and publish Docker image
 
@@ -30,7 +30,6 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=ref,event=push
             # Set the latest tag for pushes to the main branch only
             type=raw,value=latest,enable={{is_default_branch}}
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,8 +1,10 @@
-name: Build and publish Docker image
-
 on:
+  push:
+    branches: [main, master]
   pull_request:
-  push: [main, master]
+    branches: [main, master]
+
+name: Build and publish Docker image
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,6 +30,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=push
             # Set the latest tag for pushes to the main branch only
             type=raw,value=latest,enable={{is_default_branch}}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports:
     gert,
     openssl,
     pkgdepends,
-    remotes,
     withr,
     yaml
 Remotes:

--- a/R/sync.R
+++ b/R/sync.R
@@ -22,10 +22,9 @@ sync_app <- function(name, subdir, staging, root, verbose = TRUE) {
   path_lib <- path_lib(root, name)
 
   rsync_mirror_directory(path_src(root, name, subdir), dest,
-                         exclude = c(".git", ".lib", ".Rprofile"),
+                         exclude = c(".git", ".lib"),
                          verbose = verbose)
   rsync_mirror_directory(path_lib(root, name), file.path(dest, ".lib"),
                          exclude = ".conan",
                          verbose = verbose)
-  writeLines('.libPaths(".lib")', file.path(dest, ".Rprofile"))
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,18 @@ FROM rocker/shiny-verse:latest
 RUN apt-get update && apt-get install -y git git-lfs rsync \
     && rm -rf /var/lib/apt/lists/*
 
+# These are additional, but as we're the only real users of the system
+# that's fine. Used by various packages that our applications require.
+RUN apt-get update && apt-get install -y \
+    cmake \
+    gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    libglpk-dev \
+    libproj-dev \
+    libudunits2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY . /src
 
 ## For some reason 'remotes::install_local("/src")' fails to copy to

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM rocker/shiny-verse:latest
+
+# We need to install a few of these because they're required for use
+# with twinkle (both git/git-lfs and rsync will be called as shell
+# commands).
+RUN apt-get update && apt-get install -y git git-lfs rsync \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN Rscript -e 'remotes::install_github("mrc-ide/twinkle2")'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,10 +20,17 @@ RUN apt-get update && apt-get install -y \
 
 COPY . /src
 
-## For some reason 'remotes::install_local("/src")' fails to copy to
-## the tempdir, so working around this for now.  We also copy over the
-## user Rprofile file which simplifies handling of package libraries
-## to look for '.lib' in any containing directory of an application.
-RUN Rscript -e 'remotes::install_deps("/src", upgrade = FALSE)' \
+# Avoid rate limits building images without being able to easily add
+# the github token:
+RUN install2.r --error \
+    --repos https://p3m.dev/cran/__linux__/noble/latest \
+    --repos https://mrc-ide.r-universe.dev \
+    cli \
+    conan2 \
+    gert \
+    openssl \
+    pkgdepends \
+    withr \
+    yaml \
     && R CMD INSTALL "/src" \
     && cp /src/docker/Rprofile /root/.Rprofile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,5 +13,5 @@ COPY . /src
 ## user Rprofile file which simplifies handling of package libraries
 ## to look for '.lib' in any containing directory of an application.
 RUN Rscript -e 'remotes::install_deps("/src", upgrade = FALSE)' \
-    && cp /src/docker/Rprofile /root/.Rprofile \
-    && R CMD INSTALL "/src"
+    && R CMD INSTALL "/src" \
+    && cp /src/docker/Rprofile /root/.Rprofile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,4 +6,9 @@ FROM rocker/shiny-verse:latest
 RUN apt-get update && apt-get install -y git git-lfs rsync \
     && rm -rf /var/lib/apt/lists/*
 
-RUN Rscript -e 'remotes::install_github("mrc-ide/twinkle2")'
+COPY . /src
+
+## For some reason 'remotes::install_local("/src")' fails to copy to
+## the tempdir, so working around this for now
+RUN Rscript -e 'remotes::install_deps("/src", upgrade = FALSE)' \
+    && R CMD INSTALL "/src"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update && apt-get install -y git git-lfs rsync \
 COPY . /src
 
 ## For some reason 'remotes::install_local("/src")' fails to copy to
-## the tempdir, so working around this for now
+## the tempdir, so working around this for now.  We also copy over the
+## user Rprofile file which simplifies handling of package libraries
+## to look for '.lib' in any containing directory of an application.
 RUN Rscript -e 'remotes::install_deps("/src", upgrade = FALSE)' \
+    && cp /src/docker/Rprofile /root/.Rprofile \
     && R CMD INSTALL "/src"

--- a/docker/Rprofile
+++ b/docker/Rprofile
@@ -5,10 +5,11 @@ local({
       p <- paste0("/", c(parts[seq_len(i)], ".lib"), collapse = "")
       if (file.exists(p)) {
         message(sprintf("Found R library at '%s'", path))
-        return(p)
+        .libPaths(find_lib())
       }
     }
-    stop(sprintf("Did not find R library from '%s'", path))
+    message(sprintf(
+      "Did not find R library from '%s', falling back on system library",
+      path))
   }
-  .libPaths(find_lib())
 })

--- a/docker/Rprofile
+++ b/docker/Rprofile
@@ -1,0 +1,14 @@
+local({
+  find_lib <- function(path = getwd()) {
+    parts <- strsplit(path, "/")[[1]][-1]
+    for (i in rev(seq_along(parts))) {
+      p <- paste0("/", c(parts[seq_len(i)], ".lib"), collapse = "")
+      if (file.exists(p)) {
+        message(sprintf("Found R library at '%s'", path))
+        return(p)
+      }
+    }
+    stop(sprintf("Did not find R library from '%s'", path))
+  }
+  .libPaths(find_lib())
+})

--- a/docker/Rprofile
+++ b/docker/Rprofile
@@ -5,11 +5,13 @@ local({
       p <- paste0("/", c(parts[seq_len(i)], ".lib"), collapse = "")
       if (file.exists(p)) {
         message(sprintf("Found R library at '%s'", path))
-        .libPaths(find_lib())
+        .libPaths(p)
+        return(invisible())
       }
     }
     message(sprintf(
       "Did not find R library from '%s', falling back on system library",
       path))
   }
+  find_lib()
 })

--- a/docker/Rprofile
+++ b/docker/Rprofile
@@ -4,7 +4,7 @@ local({
     for (i in rev(seq_along(parts))) {
       p <- paste0("/", c(parts[seq_len(i)], ".lib"), collapse = "")
       if (file.exists(p)) {
-        message(sprintf("Found R library at '%s'", path))
+        message(sprintf("Found R library at '%s'", p))
         .libPaths(p)
         return(invisible())
       }

--- a/tests/testthat/test-sync.R
+++ b/tests/testthat/test-sync.R
@@ -20,7 +20,6 @@ test_that("can sync an app", {
   path <- path_app(root, name, TRUE)
   expect_true(file.exists(file.path(path, "app.R")))
   expect_true(file.exists(file.path(path, ".lib/pkg/file")))
-  expect_true(file.exists(file.path(path, ".Rprofile")))
   expect_false(file.exists(file.path(path, ".git")))
 })
 
@@ -37,6 +36,5 @@ test_that("can sync an app in a subdirectory", {
   path <- path_app(root, name, TRUE)
   expect_true(file.exists(file.path(path, "app.R")))
   expect_true(file.exists(file.path(path, ".lib/pkg/file")))
-  expect_true(file.exists(file.path(path, ".Rprofile")))
   expect_false(file.exists(file.path(path, ".git")))
 })


### PR DESCRIPTION
This PR adds a basic dockerfile that adds minimal deps and twinkle itself to the big boi shiny image we're building from. The approach is modified from `outpack_server`'s action and `orderly.runner`'s dockerfile. 

With this building we can depend on images like (from this PR) `ghcr.io/mrc-ide/twinkle2:build-image`, and I'll tweak the  deployment to use that